### PR TITLE
Use libjxml module from runtime

### DIFF
--- a/io.github.ecotubehq.player.json
+++ b/io.github.ecotubehq.player.json
@@ -155,64 +155,6 @@
                             ]
                         },
                         {
-                            "name": "jpeg-xl",
-                            "buildsystem": "cmake-ninja",
-                            "config-opts": [
-                                "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON",
-                                "-DJPEGXL_FORCE_SYSTEM_LCMS2=ON",
-                                "-DJPEGXL_FORCE_SYSTEM_HWY=ON",
-                                "-DJPEGXL_ENABLE_PLUGINS=OFF",
-                                "-DJPEGXL_ENABLE_TOOLS=OFF",
-                                "-DJPEGXL_ENABLE_EXAMPLES=OFF",
-                                "-DJPEGXL_ENABLE_MANPAGES=OFF",
-                                "-DJPEGXL_ENABLE_FUZZERS=OFF",
-                                "-DBUILD_TESTING=OFF"
-                            ],
-                            "post-install": [
-                                "rm $FLATPAK_DEST/lib/*.a"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/libjxl/libjxl.git",
-                                    "commit": "v0.11.0",
-                                    "x-checker-data": {
-                                        "type": "git",
-                                        "tag-pattern": "^v([\\d.]+)$"
-                                    }
-                                }
-                            ],
-                            "modules": [
-                                {
-                                    "name": "hwy",
-                                    "buildsystem": "cmake-ninja",
-                                    "config-opts": [
-                                        "-DBUILD_SHARED_LIBS=ON",
-                                        "-DHWY_ENABLE_TESTS=OFF",
-                                        "-DHWY_ENABLE_EXAMPLES=OFF",
-                                        "-DHWY_ENABLE_CONTRIB=OFF"
-                                    ],
-                                    "cleanup": [
-                                        "/include",
-                                        "/lib/pkgconfig"
-                                    ],
-                                    "sources": [
-                                        {
-                                            "type": "archive",
-                                            "url": "https://github.com/google/highway/archive/refs/tags/1.2.0.tar.gz",
-                                            "sha256": "7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343",
-                                            "x-checker-data": {
-                                                "type": "anitya",
-                                                "project-id": 205809,
-                                                "stable-only": true,
-                                                "url-template": "https://github.com/google/highway/archive/refs/tags/$version.tar.gz"
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
                             "name": "libopenmpt",
                             "config-opts": [
                                 "--disable-static",


### PR DESCRIPTION
GNOME runtime version 48 (based on the Freedesktop runtime version 24.08) appears to provide the **libjxl** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/libjxl.bst

**Other modules provided by the Freedesktop 24.08**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/platform.bst