### PR TITLE
Update several modules and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/io.github.ecotubehq.player.json
+++ b/io.github.ecotubehq.player.json
@@ -18,15 +18,12 @@
         "--talk-name=org.gtk.vfs.*"
     ],
     "cleanup": [
-        "/lib/pkgconfig",
-        "/share/ffmpeg/examples",
-        "/lib*/*/*/*.la",
         "/include",
-        "/share/man",
-        "/lib/*.la",
         "/lib/cmake",
-        "/lib/*/*.la",
-        "/lib/*.a"
+        "/lib/pkgconfig",
+        "/share/man",
+        "*.la",
+        "*.a"
     ],
     "modules": [
         {
@@ -37,9 +34,13 @@
                     "type": "git",
                     "url": "https://github.com/ecotubehq/player",
                     "tag": "26-04-01.02",
+                    "commit": "27b0bd8e158d4e28db641d7e253c0b80574112f4",
                     "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^([\\d-]+)$",
+                        "type": "json",
+                        "url": "https://api.github.com/repos/ecotubehq/player/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": "$tag | sub(\"^jq-\"; \"\")",
+                        "timestamp-query": ".published_at",
                         "is-important": true
                     }
                 }
@@ -49,8 +50,10 @@
                     "name": "libmpv",
                     "cleanup": [
                         "/share/applications",
+                        "/share/metainfo",
                         "/share/bash-completion",
                         "/share/doc",
+                        "/share/fish",
                         "/share/icons",
                         "/share/zsh"
                     ],
@@ -73,13 +76,15 @@
                         "-Dbuildtype=release",
                         "-Doptimization=2",
                         "-Db_lto=true",
-                        "-Db_ndebug=true"
+                        "-Db_ndebug=true",
+                        "-Ddebug=false",
+                        "-Dmanpage-build=disabled"
                     ],
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/mpv-player/mpv/archive/v0.40.0.tar.gz",
-                            "sha256": "10a0f4654f62140a6dd4d380dcf0bbdbdcf6e697556863dc499c296182f081a3",
+                            "url": "https://github.com/mpv-player/mpv/archive/v0.41.0.tar.gz",
+                            "sha256": "ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 5348,
@@ -89,142 +94,20 @@
                         }
                     ],
                     "modules": [
+                        "shared-modules/luajit/luajit.json",
                         {
-                            "name": "luajit",
-                            "no-autogen": true,
-                            "cleanup": [
-                                "/bin"
-                            ],
+                            "name": "libXpresent",
+                            "buildsystem": "autotools",
                             "sources": [
                                 {
                                     "type": "archive",
-                                    "url": "https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v2.1.0-beta1.tar.gz",
-                                    "sha256": "3d10de34d8020d7035193013f07c93fc7f16fcf0bb28fc03f572a21a368a5f2a"
-                                },
-                                {
-                                    "type": "shell",
-                                    "commands": [
-                                        "sed -i 's|/usr/local|/app|' ./Makefile"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "name": "libv4l2",
-                            "buildsystem": "meson",
-                            "cleanup": [
-                                "/sbin",
-                                "/bin",
-                                "/share/doc"
-                            ],
-                            "config-opts": [
-                                "-Dbpf=disabled",
-                                "-Dudevdir=/app/lib/udev",
-                                "-Dsystemdsystemunitdir=/dev/null"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "archive",
-                                    "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.28.1.tar.xz",
-                                    "sha256": "0fa075ce59b6618847af6ea191b6155565ccaa44de0504581ddfed795a328a82",
+                                    "url": "https://xorg.freedesktop.org/archive/individual/lib/libXpresent-1.0.2.tar.xz",
+                                    "sha256": "4e5b21b4812206a4b223013606ae31170502c1043038777a1ef8f70c09d37602",
                                     "x-checker-data": {
                                         "type": "anitya",
-                                        "project-id": 9998,
+                                        "project-id": 17166,
                                         "stable-only": true,
-                                        "url-template": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-$version.tar.xz"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "nv-codec-headers",
-                            "cleanup": [
-                                "*"
-                            ],
-                            "no-autogen": true,
-                            "make-install-args": [
-                                "PREFIX=/app"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "git",
-                                    "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
-                                    "tag": "n13.0.19.0",
-                                    "commit": "e844e5b26f46bb77479f063029595293aa8f812d",
-                                    "x-checker-data": {
-                                        "type": "git",
-                                        "tag-pattern": "^n([\\d.]+)$"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "libopenmpt",
-                            "config-opts": [
-                                "--disable-static",
-                                "--disable-tests",
-                                "--disable-examples",
-                                "--disable-openmpt123",
-                                "--disable-doxygen-doc",
-                                "--without-portaudio"
-                            ],
-                            "cleanup": [
-                                "/share/doc"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "archive",
-                                    "url": "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.7.9+release.autotools.tar.gz",
-                                    "sha256": "0386e918d75d797e79d5b14edd0847165d8b359e9811ef57652c0a356a2dfcf4",
-                                    "x-checker-data": {
-                                        "type": "anitya",
-                                        "project-id": 141468,
-                                        "stable-only": true,
-                                        "url-template": "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-$version+release.autotools.tar.gz"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "ffmpeg",
-                            "cleanup": [
-                                "/share/ffmpeg/examples"
-                            ],
-                            "config-opts": [
-                                "--enable-shared",
-                                "--disable-static",
-                                "--enable-gnutls",
-                                "--enable-gpl",
-                                "--disable-doc",
-                                "--disable-programs",
-                                "--disable-encoders",
-                                "--disable-muxers",
-                                "--enable-encoder=png",
-                                "--enable-encoder=libjxl",
-                                "--enable-libv4l2",
-                                "--enable-libdav1d",
-                                "--enable-libjxl",
-                                "--enable-libopenmpt",
-                                "--enable-muxer=image2",
-                                "--enable-muxer=rawvideo",
-                                "--enable-muxer=mjpeg",
-                                "--enable-encoder=bmp",
-                                "--enable-encoder=rawvideo",
-                                "--enable-filter=scale",
-                                "--enable-filter=pad",
-                                "--enable-filter=format"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "archive",
-                                    "url": "https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz",
-                                    "sha256": "733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1",
-                                    "x-checker-data": {
-                                        "type": "anitya",
-                                        "project-id": 5405,
-                                        "stable-only": true,
-                                        "url-template": "https://ffmpeg.org/releases/ffmpeg-$version.tar.xz",
-                                        "versions": { "<": "8"}
+                                        "url-template": "https://xorg.freedesktop.org/archive/individual/lib/libXpresent-$version.tar.xz"
                                     }
                                 }
                             ]
@@ -237,13 +120,13 @@
                             "sources": [
                                 {
                                     "type": "archive",
-                                    "url": "https://github.com/libass/libass/releases/download/0.17.3/libass-0.17.3.tar.xz",
-                                    "sha256": "eae425da50f0015c21f7b3a9c7262a910f0218af469e22e2931462fed3c50959",
+                                    "url": "https://github.com/libass/libass/releases/download/0.17.4/libass-0.17.4.tar.gz",
+                                    "sha256": "a886b3b80867f437bc55cff3280a652bfa0d37b43d2aff39ddf3c4f288b8c5a8",
                                     "x-checker-data": {
                                         "type": "anitya",
                                         "project-id": 1560,
                                         "stable-only": true,
-                                        "url-template": "https://github.com/libass/libass/releases/download/$version/libass-$version.tar.xz"
+                                        "url-template": "https://github.com/libass/libass/releases/download/$version/libass-$version.tar.gz"
                                     }
                                 }
                             ]
@@ -285,8 +168,8 @@
                             "sources": [
                                 {
                                     "type": "archive",
-                                    "url": "https://breakfastquay.com/files/releases/rubberband-3.3.0.tar.bz2",
-                                    "sha256": "d9ef89e2b8ef9f85b13ac3c2faec30e20acf2c9f3a9c8c45ce637f2bc95e576c",
+                                    "url": "https://breakfastquay.com/files/releases/rubberband-4.0.0.tar.bz2",
+                                    "sha256": "af050313ee63bc18b35b2e064e5dce05b276aaf6d1aa2b8a82ced1fe2f8028e9",
                                     "x-checker-data": {
                                         "type": "anitya",
                                         "project-id": 4222,
@@ -297,45 +180,21 @@
                             ]
                         },
                         {
-                            "name": "mujs",
-                            "cleanup": [
-                                "/lib/libmujs.a"
-                            ],
-                            "no-autogen": true,
-                            "make-args": [
-                                "release",
-                                "prefix=/app"
-                            ],
-                            "make-install-args": [
-                                "prefix=/app",
-                                "install-shared"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/ccxvii/mujs",
-                                    "tag": "1.3.5",
-                                    "commit": "0df0707f2f10187127e36acfbc3ba9b9ca5b5cf0",
-                                    "x-checker-data": {
-                                        "type": "git",
-                                        "tag-pattern": "^([\\d.]+)$"
-                                    }
-                                }
-                            ]
-                        },
-                        {
                             "name": "libplacebo",
                             "buildsystem": "meson",
+                            "config-opts": [
+                                "-Ddemos=false"
+                            ],
                             "sources": [
                                 {
                                     "type": "git",
                                     "url": "https://github.com/haasn/libplacebo.git",
+                                    "tag": "v7.360.1",
                                     "commit": "cee9b076f2c63104ccfd497fa79c39a867293ec4",
                                     "x-checker-data": {
                                         "type": "git",
                                         "tag-pattern": "^v([\\d.]+)$"
-                                    },
-                                    "tag": "v7.360.1"
+                                    }
                                 }
                             ]
                         }
@@ -358,8 +217,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/yt-dlp/yt-dlp.git",
-                    "tag": "2026.02.21",
-                    "commit": "e2a9cc7d137c88843e064bc9ea11cdca5cd4c82a",
+                    "tag": "2026.03.17",
+                    "commit": "7fd74d10097833ebce0cb162e0ccf7825de9b768",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"

--- a/io.github.ecotubehq.player.json
+++ b/io.github.ecotubehq.player.json
@@ -21,6 +21,9 @@
         "/include",
         "/lib/cmake",
         "/lib/pkgconfig",
+        "/share/ecotube/player-info.pdf",
+        "*-super-resolution-logo.*",
+        "/share/ladspa",
         "/share/man",
         "*.la",
         "*.a"


### PR DESCRIPTION
- Update the MPV Player to use FFMPEG and other modules from the runtime
- Update several modules
- Drop redundant modules
- eqctubehq: Use the JSON API for the version check

Based on: https://github.com/flathub/org.kde.haruna/blob/master/org.kde.haruna.yml

The installed size reduced from **67** MB to **16.7** MB.

**Please don't forget to test before merging.**